### PR TITLE
[BUGFIX] Add missing annotations to domain model class properties

### DIFF
--- a/Classes/Domain/Model/Country.php
+++ b/Classes/Domain/Model/Country.php
@@ -10,11 +10,17 @@ class Country extends AbstractEntity
      */
     protected $shortNameFa = '';
 
+    /**
+     * @return string
+     */
     public function getShortNameFa(): string
     {
         return $this->shortNameFa;
     }
 
+    /**
+     * @param string $shortNameFa
+     */
     public function setShortNameFa(string $shortNameFa)
     {
         $this->shortNameFa = $shortNameFa;

--- a/Classes/Domain/Model/CountryZone.php
+++ b/Classes/Domain/Model/CountryZone.php
@@ -5,8 +5,14 @@ namespace SJBR\StaticInfoTables\Domain\Model;
 
 class CountryZone extends AbstractEntity
 {
+    /**
+     * @var string
+     */
     protected $nameFa = '';
 
+    /**
+     * @return string
+     */
     public function getNameFa(): string
     {
         if ($this->nameFa === '') {
@@ -16,6 +22,9 @@ class CountryZone extends AbstractEntity
         return $this->nameFa;
     }
 
+    /**
+     * @param string $nameFa
+     */
     public function setNameFa(string $nameFa)
     {
         $this->nameFa = $nameFa;

--- a/Classes/Domain/Model/Currency.php
+++ b/Classes/Domain/Model/Currency.php
@@ -5,25 +5,43 @@ namespace SJBR\StaticInfoTables\Domain\Model;
 
 class Currency extends AbstractEntity
 {
+    /**
+     * @var string
+     */
     protected $nameFa = '';
 
+    /**
+     * @var string
+     */
     protected $subdivisionNameFa = '';
 
+    /**
+     * @return string
+     */
     public function getNameFa(): string
     {
         return $this->nameFa;
     }
 
+    /**
+     * @param string $nameFa
+     */
     public function setNameFa(string $nameFa)
     {
         $this->nameFa = $nameFa;
     }
 
+    /**
+     * @return string
+     */
     public function getSubdivisionNameFa(): string
     {
         return $this->subdivisionNameFa;
     }
 
+    /**
+     * @param string $subdivisionNameFa
+     */
     public function setSubdivisionNameFa(string $subdivisionNameFa)
     {
         $this->subdivisionNameFa = $subdivisionNameFa;

--- a/Classes/Domain/Model/Language.php
+++ b/Classes/Domain/Model/Language.php
@@ -5,13 +5,22 @@ namespace SJBR\StaticInfoTables\Domain\Model;
 
 class Language extends AbstractEntity
 {
+    /**
+     * @var string
+     */
     protected $nameFa = '';
 
+    /**
+     * @return string
+     */
     public function getNameFa(): string
     {
         return $this->nameFa;
     }
 
+    /**
+     * @param string $nameFa
+     */
     public function setNameFa(string $nameFa)
     {
         $this->nameFa = $nameFa;

--- a/Classes/Domain/Model/Territory.php
+++ b/Classes/Domain/Model/Territory.php
@@ -5,13 +5,22 @@ namespace SJBR\StaticInfoTables\Domain\Model;
 
 class Territory extends AbstractEntity
 {
+    /**
+     * @var string
+     */
     protected $nameFa = '';
 
+    /**
+     * @return string
+     */
     public function getNameFa(): string
     {
         return $this->nameFa;
     }
 
+    /**
+     * @param string $nameFa
+     */
     public function setNameFa(string $nameFa)
     {
         $this->nameFa = $nameFa;


### PR DESCRIPTION
This prevents error in backend "Could not determine the child object type".